### PR TITLE
Possibility to not popup money after using Player.AddMoney or Player.RemoveMoney

### DIFF
--- a/server/player.lua
+++ b/server/player.lua
@@ -284,8 +284,9 @@ function RSGCore.Player.CreatePlayer(PlayerData, Offline)
         self.Functions.UpdatePlayerData()
     end
 
-    function self.Functions.AddMoney(moneytype, amount, reason)
+    function self.Functions.AddMoney(moneytype, amount, reason, showhud)
         reason = reason or "unknown"
+		showhud = showhud or true
         moneytype = moneytype:lower()
         amount = tonumber(amount)
         if amount < 0 then
@@ -346,7 +347,7 @@ function RSGCore.Player.CreatePlayer(PlayerData, Offline)
                         .. reason
                 )
             end
-            TriggerClientEvent("hud:client:OnMoneyChange", self.PlayerData.source, moneytype, amount, false)
+            if showhud then TriggerClientEvent("hud:client:OnMoneyChange", self.PlayerData.source, moneytype, amount, false) end
             TriggerClientEvent("RSGCore:Client:OnMoneyChange", self.PlayerData.source, moneytype, amount, "add", reason)
             TriggerEvent("RSGCore:Server:OnMoneyChange", self.PlayerData.source, moneytype, amount, "add", reason)
         end
@@ -354,8 +355,9 @@ function RSGCore.Player.CreatePlayer(PlayerData, Offline)
         return true
     end
 
-    function self.Functions.RemoveMoney(moneytype, amount, reason)
+    function self.Functions.RemoveMoney(moneytype, amount, reason, showhud)
         reason = reason or "unknown"
+		showhud = showhud or true
         moneytype = moneytype:lower()
         amount = tonumber(amount)
         if amount < 0 then
@@ -423,7 +425,7 @@ function RSGCore.Player.CreatePlayer(PlayerData, Offline)
                         .. reason
                 )
             end
-            TriggerClientEvent("hud:client:OnMoneyChange", self.PlayerData.source, moneytype, amount, true)
+            if showhud then TriggerClientEvent("hud:client:OnMoneyChange", self.PlayerData.source, moneytype, amount, true) end
             TriggerClientEvent("RSGCore:Client:OnMoneyChange", self.PlayerData.source, moneytype, amount, "remove", reason)
             TriggerEvent("RSGCore:Server:OnMoneyChange", self.PlayerData.source, moneytype, amount, "remove", reason)
         end


### PR DESCRIPTION
Added possibility to hide money popup using func Player.AddMoney and Player.RemoveMoney.

It is very useful for make others scripts that shows money using ox_lib notify or any other script.

AddMoney(moneytype, amount, reason, showhud)
RemoveMoney(moneytype, amount, reason, showhud)

Set showhud false to not show money popup.
You can not set any param to get true (Shows popups) as default.