### PR TITLE
Support for money items, csrf protection api

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -223,3 +223,8 @@ if RSGConfig.HidePlayerNames then
         end
     end)
 end
+
+RegisterNUICallback('validateCSRF', function(data, cb)
+    local isValid = lib.callback.await('RSGCore:Server:ValidateCSRF', false, data.clientToken)
+    cb({ valid = isValid })
+end)

--- a/config.lua
+++ b/config.lua
@@ -12,6 +12,7 @@ RSGConfig.Money.DontAllowMinus = { 'cash', 'bloodmoney' }            -- Money th
 RSGConfig.Money.MinusLimit = -5000                                    -- The maximum amount you can be negative 
 RSGConfig.Money.PayCheckTimeOut = 10                                 -- The time in minutes that it will give the paycheck
 RSGConfig.Money.PayCheckSociety = false                              -- If true paycheck will come from the society account that the player is employed at, requires rsg-management
+RSGConfig.Money.EnableMoneyItems = true                              -- If true cash and bloodmoney will be represented wih inventory items
 
 RSGConfig.Player = {}
 RSGConfig.Player.HungerRate = 4.2 -- Rate at which hunger goes down.

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -37,6 +37,7 @@ server_scripts {
     '@oxmysql/lib/MySQL.lua',
     'server/main.lua',
     'server/functions.lua',
+    'server/moneyitems.lua',
     'server/player.lua',
     'server/events.lua',
     'server/commands.lua',

--- a/server/events.lua
+++ b/server/events.lua
@@ -231,3 +231,24 @@ RSGCore.Functions.CreateCallback('RSGCore:Server:SpawnVehicle', function(source,
     local veh = RSGCore.Functions.SpawnVehicle(source, model, coords, warp)
     cb(NetworkGetNetworkIdFromEntity(veh))
 end)
+
+-- csrf protection
+
+local csrfTokens = {}
+
+lib.callback.register('RSGCore:Server:GenerateToken', function(src)
+    local token = tostring(math.random(100000, 999999)) .. os.time()
+    csrfTokens[src] = token
+
+    return token
+end)
+
+lib.callback.register('RSGCore:Server:ValidateCSRF', function(src, clientToken)
+    if csrfTokens[src] and csrfTokens[src] == clientToken then
+        csrfTokens[src] = nil
+        return true
+    else
+        DropPlayer(src, "CSRF validation failed.") -- possible expoit attempt
+        return false
+    end
+end)

--- a/server/moneyitems.lua
+++ b/server/moneyitems.lua
@@ -41,7 +41,7 @@ local function getInventoryMoney(playerData)
     return money
 end
 
-local function removeItems(itemName, amountToRemove)
+local function removeItems(player, itemName, amountToRemove)
     for _, item in ipairs(player.Functions.GetItemsByName(itemName) or {}) do
         local removeAmount = math.min(item.amount, amountToRemove)
         player.Functions.RemoveItem(item.name, removeAmount, item.slot)

--- a/server/moneyitems.lua
+++ b/server/moneyitems.lua
@@ -1,0 +1,234 @@
+---------------------------------------------------
+-- Helper tables to map money items - do not change
+---------------------------------------------------
+
+local moneyItems = {
+    cash = {
+        dollar = 'dollar',
+        cent = 'cent',
+    },
+    bloodmoney = {
+        dollar = 'blood_dollar',
+        cent = 'blood_cent',
+    },
+}
+
+local moneyMap = {
+    dollar = "cashDollars",
+    cent = "cashCents",
+    blood_dollar = "bloodDollars",
+    blood_cent = "bloodCents"
+}
+
+-------------------
+-- Helper functions
+-------------------
+
+local function getInventoryMoney(playerData) 
+    local money = {
+        cashDollars = 0,
+        cashCents = 0,
+        bloodDollars = 0,
+        bloodCents = 0
+    }
+
+    for _, item in pairs(playerData.items) do
+        if item and moneyMap[item.name] then
+            money[moneyMap[item.name]] = money[moneyMap[item.name]] + item.amount
+        end
+    end
+
+    return money
+end
+
+local function removeItems(itemName, amountToRemove)
+    for _, item in ipairs(player.Functions.GetItemsByName(itemName) or {}) do
+        local removeAmount = math.min(item.amount, amountToRemove)
+        player.Functions.RemoveItem(item.name, removeAmount, item.slot)
+        amountToRemove = amountToRemove - removeAmount
+        if amountToRemove <= 0 then break end
+    end
+end
+
+local function getParts(number)
+    local integerPart, decimalPart = math.modf(number)
+    local decimalValue = math.floor(decimalPart * 100)
+    return integerPart, decimalValue
+end
+
+local function calculateTotal(dollars, cents)
+    return tonumber(string.format("%.2f", dollars + (cents / 100)))
+end
+
+----------------------------
+-- Money operations hanlders
+----------------------------
+
+local function handleAddMoney(src, moneytype, amount)
+    local player = RSGCore.Functions.GetPlayer(src)
+    if not player or not moneyItems[moneytype] then return end
+
+    local dollars, cents = math.modf(amount)
+    cents = math.floor((cents * 100) + 0.5)
+
+    if dollars > 0 then 
+        player.Functions.AddItem(moneyItems[moneytype].dollar, dollars)
+    end
+    if cents > 0 then
+        player.Functions.AddItem(moneyItems[moneytype].cent, cents)
+    end
+
+    if Player(src).state.inv_busy then
+        TriggerClientEvent('rsg-inventory:client:updateInventory', src)
+    end
+end
+
+local function handleRemoveMoney(src, moneytype, amount)
+    local player = RSGCore.Functions.GetPlayer(src)
+    if not player or not moneyItems[moneytype] then return end
+
+    local amountDollars, amountCents = getParts(amount)
+    local inventoryMoney = getInventoryMoney(player.PlayerData)
+
+    local availableDollars = inventoryMoney[moneyMap[moneyItems[moneytype].dollar]] or 0
+    local availableCents = inventoryMoney[moneyMap[moneyItems[moneytype].cent]] or 0
+
+    local remainingCentValue = amount * 100
+    local centsToRemove, dollarsToRemove, centsToAdd = 0, 0, 0
+
+    if amountCents > 0 and availableCents >= amountCents then
+        centsToRemove = amountCents
+        availableCents = availableCents - amountCents
+        remainingCentValue = remainingCentValue - amountCents
+
+        local availableHundredBlocks = math.floor(availableCents / 100)
+        if availableHundredBlocks > 0 and amountDollars > 0 then
+            local dollarsFromCents = math.min(availableHundredBlocks, amountDollars)
+            local additionalCentsToUse = dollarsFromCents * 100
+
+            centsToRemove = centsToRemove + additionalCentsToUse
+            remainingCentValue = remainingCentValue - additionalCentsToUse
+            amountDollars = amountDollars - dollarsFromCents
+        end
+    end
+
+    if amountDollars > 0 then
+        dollarsToRemove = amountDollars
+        remainingCentValue = remainingCentValue - (amountDollars * 100)
+    end
+
+    if remainingCentValue > 0 then
+        dollarsToRemove = dollarsToRemove + 1
+        centsToAdd = 100 - remainingCentValue
+    end
+
+    local centName = moneyItems[moneytype].cent
+    local dollarName = moneyItems[moneytype].dollar
+
+    if centsToRemove > 0 then removeItems(player, centName, centsToRemove) end
+    if dollarsToRemove > 0 then removeItems(player, dollarName, dollarsToRemove) end
+    if centsToAdd > 0 then player.Functions.AddItem(centName, centsToAdd) end
+
+    if Player(src).state.inv_busy then
+        TriggerClientEvent('rsg-inventory:client:updateInventory', src)
+    end
+end
+
+local function handleSetMoney(src, moneytype, amount) 
+    local player = RSGCore.Functions.GetPlayer(src)
+    if not player or not moneyItems[moneytype] then return end
+
+    local function removeAllItems(itemName)
+        for _, item in ipairs(player.Functions.GetItemsByName(itemName) or {}) do
+            player.Functions.RemoveItem(item.name, item.amount, item.slot)
+        end
+    end
+
+    removeAllItems(moneyItems[moneytype].cent)
+    removeAllItems(moneyItems[moneytype].dollar)
+
+    local dollars, cents = math.modf(amount)
+    cents = math.floor(cents * 100)
+
+    if dollars > 0 then player.Functions.AddItem(moneyItems[moneytype].dollar, dollars) end
+    if cents > 0 then player.Functions.AddItem(moneyItems[moneytype].cent, cents) end
+
+    if Player(src).state.inv_busy then 
+        TriggerClientEvent('rsg-inventory:client:updateInventory', src) 
+    end
+end
+
+-----------------------------------------------------------------
+-- If config changed, handle inventory items accordingly on login
+-----------------------------------------------------------------
+
+local initialized = false
+RegisterNetEvent('RSGCore:Server:OnPlayerLoaded')
+AddEventHandler('RSGCore:Server:OnPlayerLoaded', function()
+    local src = source
+    local player = RSGCore.Functions.GetPlayer(src)
+    if not player then return end
+
+    local money = getInventoryMoney(player.PlayerData)
+
+    if RSGCore.Config.Money.EnableMoneyItems then
+        local cash = calculateTotal(money.cashDollars, money.cashCents)
+        local bloodmoney = calculateTotal(money.bloodDollars, money.bloodCents)
+
+        if cash ~= player.PlayerData.money.cash then
+            handleSetMoney(src, 'cash', player.PlayerData.money.cash)
+        end
+
+        if bloodmoney ~= player.PlayerData.money.bloodmoney then
+            handleSetMoney(src, 'bloodmoney', player.PlayerData.money.bloodmoney)
+        end
+    else
+        local function removeAllItems(itemName)
+            for _, item in ipairs(player.Functions.GetItemsByName(itemName) or {}) do
+                player.Functions.RemoveItem(item.name, item.amount, item.slot, 'money-item-cleanup')
+            end
+        end
+    
+        removeAllItems(moneyItems['cash'].cent)
+        removeAllItems(moneyItems['cash'].dollar)
+        removeAllItems(moneyItems['bloodmoney'].cent)
+        removeAllItems(moneyItems['bloodmoney'].dollar)
+    end
+
+    -- failsafe to prevent early override by synchronization
+    initialized = true
+end)
+
+-------------------------------------------------------------
+-- Enable handlers and synchronization when enabled in config
+-------------------------------------------------------------
+
+if RSGCore.Config.Money.EnableMoneyItems then
+
+    local moneyHandlers = {
+        add = handleAddMoney,
+        remove = handleRemoveMoney,
+        set = handleSetMoney,
+    }
+
+    AddEventHandler('RSGCore:Server:OnMoneyChange', function(src, moneytype, amount, operation, reason)
+        local handler = moneyHandlers[operation]
+        if handler then 
+            handler(src, moneytype, amount) 
+            TriggerClientEvent('hud:client:OnMoneyChange', src, moneytype, amount, false)
+        end
+    end)
+
+    function SynchronizeMoneyItems(playerData)
+        if not initialized then return playerData end
+    
+        local money = getInventoryMoney(playerData) 
+    
+        playerData.money.cash = calculateTotal(money.cashDollars, money.cashCents)
+        playerData.money.bloodmoney = calculateTotal(money.bloodDollars, money.bloodCents)
+    
+        return playerData
+    end
+
+end
+

--- a/server/player.lua
+++ b/server/player.lua
@@ -175,6 +175,11 @@ function RSGCore.Player.CreatePlayer(PlayerData, Offline)
 
     function self.Functions.UpdatePlayerData()
         if self.Offline then return end
+
+        if RSGCore.Config.Money.EnableMoneyItems then
+            self.PlayerData = SynchronizeMoneyItems(self.PlayerData)
+        end
+
         TriggerEvent('RSGCore:Player:SetPlayerData', self.PlayerData)
         TriggerClientEvent('RSGCore:Player:SetPlayerData', self.PlayerData.source, self.PlayerData)
     end

--- a/shared/items.lua
+++ b/shared/items.lua
@@ -47,6 +47,12 @@ RSGShared.Items = {
     -- Bird Post
     birdpost = { name = 'birdpost', label = 'Bird Post', weight = 5, type = 'item', image = 'birdpost.png', unique = false, useable = true, shouldClose = true, description = 'Bird Post for sending letters' },
 
+    -- MoneyItems
+    dollar = {name = 'dollar', label = 'Dollars', weight = 1, type = 'item', image = 'dollar.png', unique = false, useable = false, description = 'Standard currency used for everyday transactions'},
+    cent = {name = 'cent', label = 'Cents', weight = 3, type = 'item', image = 'cent.png', unique = false, useable = false, description = 'Small denomination of currency, commonly used for change'},
+    blood_dollar = {name = 'blood_dollar', label = 'Bloodstained Dollars', weight = 1, type = 'item', image = 'blood_dollar.png', unique = false, useable = false, description = 'Currency tainted by violence and crime'},
+    blood_cent = {name = 'blood_cent', label = 'Bloodstained Cents', weight = 3, type = 'item', image = 'blood_cent.png', unique = false, useable = false, description = 'Small change stained with the remnants of bloodshed'},
+
     -- Money Clip
     money_clip       = { name = 'money_clip',       label = 'Money Clip',       weight = 1, type = 'item', image = 'money_clip.png',       unique = true, useable = true, shouldClose = true, description = 'Money Clip' },
     blood_money_clip = { name = 'blood_money_clip', label = 'Blood Money Clip', weight = 1, type = 'item', image = 'blood_money_clip.png', unique = true, useable = true, shouldClose = true, description = 'Blood Money Clip' },


### PR DESCRIPTION
### **Config change!!!**
```lua
--added
RSGConfig.Money.EnableMoneyItems = true
```

### **Money items**
 - similar to https://github.com/realmarcuzz/ath-money
 - improved money handling so it follows real life scenarios to avoid situations where we delete cents and add change with same value when paying whole dollar values and such
 - it is now possible to seamlessly enable/disable this option in config without resetting player money
 - item icons added to inventory PR
 
### **CSRF protection**
 - added callbacks to generate and validate csrf token - utilized in inventory PR
  