### PR TITLE
Create weight and slot usability to be individual for each player

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -82,6 +82,8 @@ RSGConfig.Player.PlayerDefaults = {
     },
     position = RSGConfig.DefaultSpawn,
     items = {},
+    weight = 35000,
+    slots = 25,
 }
 
 RSGConfig.Server = {}                                    -- General server config

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -5,7 +5,7 @@ game 'rdr3'
 lua54 'yes'
 
 description 'rsg-core'
-version '2.2.3'
+version '2.3.0'
 
 shared_scripts {
     '@ox_lib/init.lua',

--- a/rsg-core.sql
+++ b/rsg-core.sql
@@ -12,6 +12,8 @@ CREATE TABLE IF NOT EXISTS `players` (
   `position` text NOT NULL,
   `metadata` text NOT NULL,
   `inventory` longtext DEFAULT NULL,
+  `weight` int(11) NOT NULL DEFAULT 0,
+  `slots` int(11) NOT NULL DEFAULT 0,
   `last_updated` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
   PRIMARY KEY (`citizenid`),
   KEY `id` (`id`),

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -660,3 +660,25 @@ function RSGCore.Functions.PrepForSQL(source, data, pattern)
     end
     return true
 end
+
+---Change weight to player
+---@param source any
+---@param weight number
+---@return boolean
+function RSGCore.Functions.ChangeWeight(source, weight)
+    local Player = RSGCore.Functions.GetPlayer(source)
+    if not Player then return end
+
+    Player.Functions.SetPlayerData('weight', weight)
+end
+
+---Change slots to player
+---@param source any
+---@param slots number
+---@return boolean
+function RSGCore.Functions.ChangeSlots(source, slots)
+    local Player = RSGCore.Functions.GetPlayer(source)
+    if not Player then return end
+
+    Player.Functions.SetPlayerData('slots', slots)
+end

--- a/server/player.lua
+++ b/server/player.lua
@@ -530,7 +530,7 @@ function RSGCore.Player.Save(source)
     local pcoords = GetEntityCoords(ped)
     local PlayerData = RSGCore.Players[source].PlayerData
     if PlayerData then
-        MySQL.insert('INSERT INTO players (citizenid, cid, license, name, money, charinfo, job, gang, position, metadata) VALUES (:citizenid, :cid, :license, :name, :money, :charinfo, :job, :gang, :position, :metadata) ON DUPLICATE KEY UPDATE cid = :cid, name = :name, money = :money, charinfo = :charinfo, job = :job, gang = :gang, position = :position, metadata = :metadata', {
+        MySQL.insert('INSERT INTO players (citizenid, cid, license, name, money, charinfo, job, gang, position, metadata, weight, slots) VALUES (:citizenid, :cid, :license, :name, :money, :charinfo, :job, :gang, :position, :metadata, :weight, :slots) ON DUPLICATE KEY UPDATE cid = :cid, name = :name, money = :money, charinfo = :charinfo, job = :job, gang = :gang, position = :position, metadata = :metadata, weight = :weight, slots = :slots', {
             citizenid = PlayerData.citizenid,
             cid = tonumber(PlayerData.cid),
             license = PlayerData.license,
@@ -540,7 +540,9 @@ function RSGCore.Player.Save(source)
             job = json.encode(PlayerData.job),
             gang = json.encode(PlayerData.gang),
             position = json.encode(pcoords),
-            metadata = json.encode(PlayerData.metadata)
+            metadata = json.encode(PlayerData.metadata),
+            weight = PlayerData.weight,
+            slots = PlayerData.slots,
         })
         if GetResourceState('rsg-inventory') ~= 'missing' then exports['rsg-inventory']:SaveInventory(source) end
         RSGCore.ShowSuccess(resourceName, PlayerData.name .. ' PLAYER SAVED!')
@@ -551,7 +553,7 @@ end
 
 function RSGCore.Player.SaveOffline(PlayerData)
     if PlayerData then
-        MySQL.insert('INSERT INTO players (citizenid, cid, license, name, money, charinfo, job, gang, position, metadata) VALUES (:citizenid, :cid, :license, :name, :money, :charinfo, :job, :gang, :position, :metadata) ON DUPLICATE KEY UPDATE cid = :cid, name = :name, money = :money, charinfo = :charinfo, job = :job, gang = :gang, position = :position, metadata = :metadata', {
+        MySQL.insert('INSERT INTO players (citizenid, cid, license, name, money, charinfo, job, gang, position, metadata, weight, slots) VALUES (:citizenid, :cid, :license, :name, :money, :charinfo, :job, :gang, :position, :metadata, :weight, :slots) ON DUPLICATE KEY UPDATE cid = :cid, name = :name, money = :money, charinfo = :charinfo, job = :job, gang = :gang, position = :position, metadata = :metadata, weight = :weight, slots = :slots', {
             citizenid = PlayerData.citizenid,
             cid = tonumber(PlayerData.cid),
             license = PlayerData.license,
@@ -561,7 +563,9 @@ function RSGCore.Player.SaveOffline(PlayerData)
             job = json.encode(PlayerData.job),
             gang = json.encode(PlayerData.gang),
             position = json.encode(PlayerData.position),
-            metadata = json.encode(PlayerData.metadata)
+            metadata = json.encode(PlayerData.metadata),
+            weight = PlayerData.weight,
+            slots = PlayerData.slots,
         })
         if GetResourceState('rsg-inventory') ~= 'missing' then exports['rsg-inventory']:SaveInventory(PlayerData, true) end
         RSGCore.ShowSuccess(resourceName, PlayerData.name .. ' OFFLINE PLAYER SAVED!')
@@ -569,6 +573,7 @@ function RSGCore.Player.SaveOffline(PlayerData)
         RSGCore.ShowError(resourceName, 'ERROR RSGCore.PLAYER.SAVEOFFLINE - PLAYERDATA IS EMPTY!')
     end
 end
+
 
 -- Delete character
 


### PR DESCRIPTION
This new feature allows players to have different weights/slots from each other. This information is saved in the database along with the player's data.

With these new options, players can use the ChangeWeight and ChangeSlots methods to add or remove weight/slots from their characters.

It needs to be released along with the changes to rsg-inventory.